### PR TITLE
changed /plex_logs to /log in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Support is available on [Discord](https://tautulli.com/discord), [Reddit](https:
 docker create \
   --name=tautulli \
   -v <path to data>:/config \
-  -v <path to plexlogs>:/plex_logs:ro \
+  -v <path to plexlogs>:/logs:ro \
   -e PGID=<gid> -e PUID=<uid>  \
   -e TZ=<timezone> \
   -p 8181:8181 \
@@ -43,7 +43,7 @@ So `-p 8181:8181` would expose port `8181` from inside the container to be acces
 | :---: | --- |
 | `-p 8181` | Port for webui |
 | `-v /config` | Contains tautulli config and database |
-| `-v /plex_logs` | Map this to [Plex log directory](https://support.plex.tv/articles/200250417-plex-media-server-log-files/) |
+| `-v /logs` | Map this to [Plex log directory](https://support.plex.tv/articles/200250417-plex-media-server-log-files/) |
 | `-e PGID` | GroupID (see below) |
 | `-e PUID` | UserID (see below) |
 | `-e TZ` | For setting timezone (ex. America/Toronto) |


### PR DESCRIPTION
The Volume directory `/plex_logs` from the readme don't match the volume definition in the Dockerfile. The PlexMediaServer log directory from the host needs to be mounted to `/log` instead of `plex_logs` inside the container to work properly. 
The corresponding Volume definition can be seen [here](https://github.com/Tautulli/Tautulli-Docker/blob/4e2a4c5a4f7e8fb99b25ed878133388ecf31996e/Dockerfile#L76) 